### PR TITLE
Avoid match error when hackney gets a 403 back

### DIFF
--- a/test/fastimage_test.exs
+++ b/test/fastimage_test.exs
@@ -99,6 +99,10 @@ defmodule FastimageTest do
     assert list_results == list_expected_results(n)
   end
 
+  test "403 on remote file request returns error tuple" do
+    assert {:error, %Fastimage.Error{}} = Fastimage.type("http://httpstat.us/403")
+  end
+
   # private
 
   defp assert_size_and_type(input, expected_size, expected_type) do


### PR DESCRIPTION
If `get_acc_with_type/3` returns anything other than `{:ok, %Stream.Acc{}}` we get a match error like:
```
** (MatchError) no match of right hand side value: {:error, %Fastimage.Error{reason: {:hackney_response_error, {"https://url.that.returns/403.jpg", 404, "Not Found"}}}}
    (fastimage) lib/fastimage.ex:70: Fastimage.type/2
```
I added a very simple test case, which uses a service that just returns a status code based on the url you request, http://httpstat.us/. I usually would avoid write a unit test that makes network calls, but the test suite already does that. An alternative could be to introduce an `HttpClient` behaviour, and then use https://hexdocs.pm/mox/Mox.html in the tests.