### PR TITLE
Height can be negative for bmp

### DIFF
--- a/lib/fastimage/parser.ex
+++ b/lib/fastimage/parser.ex
@@ -203,13 +203,13 @@ defmodule Fastimage.Parser do
         40 ->
           part = :erlang.binary_part(new_bytes, {4, :erlang.byte_size(new_bytes) - 5})
           <<width::little-unsigned-integer-size(32), rest::binary>> = part
-          <<height::little-unsigned-integer-size(32), _rest::binary>> = rest
+          <<height::little-signed-integer-size(32), _rest::binary>> = rest
           %{width: width, height: height}
 
         _ ->
           part = :erlang.binary_part(new_bytes, {4, 8})
           <<width::native-unsigned-integer-size(16), rest::binary>> = part
-          <<height::native-unsigned-integer-size(16), _rest::binary>> = rest
+          <<height::native-signed-integer-size(16), _rest::binary>> = rest
           %{width: width, height: height}
       end
 

--- a/lib/fastimage/parser.ex
+++ b/lib/fastimage/parser.ex
@@ -197,16 +197,14 @@ defmodule Fastimage.Parser do
   def parse_bmp(data) do
     new_bytes = :erlang.binary_part(data, {14, 14})
     <<char::8, _rest::binary>> = new_bytes
-
     %{width: width, height: height} =
-      case char do
-        40 ->
+      if char >= 40 do
           part = :erlang.binary_part(new_bytes, {4, :erlang.byte_size(new_bytes) - 5})
           <<width::little-unsigned-integer-size(32), rest::binary>> = part
           <<height::little-signed-integer-size(32), _rest::binary>> = rest
           %{width: width, height: height}
 
-        _ ->
+      else
           part = :erlang.binary_part(new_bytes, {4, 8})
           <<width::native-unsigned-integer-size(16), rest::binary>> = part
           <<height::native-signed-integer-size(16), _rest::binary>> = rest


### PR DESCRIPTION
Hi, 

Thanks for a very useful library. 
This patch allows the height for bmp to be negative, this is used to indicate the order of the pixels (starting from top or bottom). Without the patch the height becomes a nonsensical number for this images.

Thanks
